### PR TITLE
CB2-11288: Amend Doc Retrieval - Add GetZIP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,4 +47,4 @@ reports
 buckets/
 
 # Idea specific hidden files
- .idea/**
+.idea/**

--- a/docs/spec.yml
+++ b/docs/spec.yml
@@ -54,6 +54,12 @@ paths:
           required: false
           schema:
             type: string
+        - name: adrDocumentId
+          in: query
+          description: ADR Document ID
+          required: false
+          schema:
+            type: string
 
       responses:
         '200':

--- a/src/domain/documentRequestFactory.ts
+++ b/src/domain/documentRequestFactory.ts
@@ -89,7 +89,7 @@ export default async (vin: string, testNumber: string, plateSerialNumber: string
       },
       s3,
       `cvs-cert-${BUCKET}`,
-      BRANCH.concat('/adr-documents'),
+      `${BRANCH}/adr-documents`,
       NODE_ENV,
     );
   }

--- a/src/domain/documentRequestFactory.ts
+++ b/src/domain/documentRequestFactory.ts
@@ -89,7 +89,7 @@ export default async (vin: string, testNumber: string, plateSerialNumber: string
       },
       s3,
       `cvs-cert-${BUCKET}`,
-      `${BRANCH}/adr-documents`,
+      BRANCH,
       NODE_ENV,
     );
   }

--- a/src/domain/getZip.ts
+++ b/src/domain/getZip.ts
@@ -1,0 +1,93 @@
+/* eslint-disable  @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-base-to-string */
+
+import { S3, AWSError } from 'aws-sdk';
+import { APIGatewayProxyResult } from 'aws-lambda';
+import getObjectFromS3 from '../infrastructure/s3/s3ZipService';
+import NoBodyError from '../errors/NoBodyError';
+import MissingBucketNameError from '../errors/MissingBucketNameError';
+import IncorrectFileTypeError from '../errors/IncorrectFileTypeError';
+import MissingFolderNameError from '../errors/MissingFolderNameError';
+import FileNameError from '../errors/FileNameError';
+import ZipDetails from '../interfaces/ZipDetails';
+
+function isAWSError(error: Error | AWSError): error is AWSError {
+  return Object.prototype.hasOwnProperty.call(error, 'code') as boolean;
+}
+
+export default async (
+  event: ZipDetails,
+  s3: S3,
+  bucketName: string | undefined,
+  folder: string | undefined,
+  currentEnvironment: string | undefined,
+): Promise<APIGatewayProxyResult> => {
+  try {
+    if (!bucketName) {
+      throw new MissingBucketNameError();
+    }
+    if (currentEnvironment !== 'local' && !folder) {
+      throw new MissingFolderNameError();
+    }
+
+    console.log(`Validating: ${event.adrDocumentId}`);
+
+    if (!event.adrDocumentId) {
+      throw new FileNameError();
+    }
+
+    const file = await getObjectFromS3(s3, bucketName, folder, event.adrDocumentId);
+    const response = file.toString('base64');
+
+    const headers = {
+      'Content-type': 'application/zip',
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Credentials': true,
+      'X-Content-Type-Options': 'nosniff',
+      Vary: 'Origin',
+      'X-XSS-Protection': '1; mode=block',
+    };
+
+    return {
+      headers,
+      statusCode: 200,
+      body: response,
+      isBase64Encoded: true,
+    };
+  } catch (e) {
+    let code = 500;
+    let message = '';
+
+    // Split into 50x and 40x errors.
+    if (e instanceof NoBodyError || e instanceof MissingBucketNameError || e instanceof MissingFolderNameError) {
+      message = e.message;
+    }
+
+    if (e instanceof FileNameError) {
+      code = 400;
+      message = e.message;
+    }
+
+    if (e instanceof IncorrectFileTypeError) {
+      code = 404;
+      message = e.message;
+    }
+
+    if (isAWSError(e)) {
+      // S3 error that the key does not exist
+      if (['NoSuchKey'].includes(e.code)) {
+        code = 404;
+      }
+
+      // Any other AWS errors we get will always be a 500 because it will be an error on our part.
+      message = e.code;
+    }
+
+    console.error(code);
+    console.error(message);
+
+    return {
+      statusCode: code,
+      body: message,
+    };
+  }
+};

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -4,8 +4,6 @@ import { Context, APIGatewayEvent, APIGatewayProxyStructuredResultV2 } from 'aws
 import { app } from './infrastructure/api';
 
 const handler = async (event: APIGatewayEvent, context: Context): Promise<APIGatewayProxyStructuredResultV2> => {
-  console.log(event);
-
   return serverless(app, {
     /**
      * We proxy requests from / as <stage> is handled in APIG when we deploy.

--- a/src/infrastructure/api/index.ts
+++ b/src/infrastructure/api/index.ts
@@ -16,10 +16,10 @@ app.get('/version', (_request, res) => {
 
 app.get('/document-retrieval', (req: Request, res: Response) => {
   const {
-    vinNumber, plateSerialNumber, testNumber, systemNumber, fileName,
+    vinNumber, plateSerialNumber, testNumber, systemNumber, fileName, adrDocumentId,
   } = req.query;
 
-  documentRequestFactory(vinNumber as string, testNumber as string, plateSerialNumber as string, systemNumber as string, fileName as string)
+  documentRequestFactory(vinNumber as string, testNumber as string, plateSerialNumber as string, systemNumber as string, fileName as string, adrDocumentId as string)
     .then(({ statusCode, headers, body }) => {
       res.status(statusCode);
 

--- a/src/infrastructure/s3/s3ZipService.ts
+++ b/src/infrastructure/s3/s3ZipService.ts
@@ -1,0 +1,34 @@
+import { S3 } from 'aws-sdk';
+import IncorrectFileTypeError from '../../errors/IncorrectFileTypeError';
+import NoBodyError from '../../errors/NoBodyError';
+
+export default async (
+  s3: S3,
+  bucket: string,
+  folder: string | undefined,
+  adrDocumentId: string,
+): Promise<S3.Body> => {
+  const key = folder ? `${folder}/${adrDocumentId}.zip` : `${adrDocumentId}.zip`;
+
+  console.info(`Bucket name: ${bucket}`);
+  console.info(`Item key: ${key}`);
+
+  const response = await s3
+    .getObject({
+      Bucket: bucket,
+      Key: key,
+    })
+    .promise();
+
+  if (response.ContentType !== 'application/octet-stream' && response.ContentType !== 'application/zip') {
+    // TODO: Cover this in case we encrypt the zip as octet stream or some other form
+    console.error(`Incorrect content-type: ${response.ContentType}`);
+    throw new IncorrectFileTypeError();
+  }
+
+  if (response.Body) {
+    return response.Body;
+  }
+
+  throw new NoBodyError();
+};

--- a/src/infrastructure/s3/s3ZipService.ts
+++ b/src/infrastructure/s3/s3ZipService.ts
@@ -8,7 +8,7 @@ export default async (
   folder: string | undefined,
   adrDocumentId: string,
 ): Promise<S3.Body> => {
-  const key = folder ? `${folder}/${adrDocumentId}.zip` : `${adrDocumentId}.zip`;
+  const key = folder ? `${folder}/adr-documents/${adrDocumentId}.zip` : `/adr-documents/${adrDocumentId}.zip`;
 
   console.info(`Bucket name: ${bucket}`);
   console.info(`Item key: ${key}`);

--- a/src/interfaces/ZipDetails.ts
+++ b/src/interfaces/ZipDetails.ts
@@ -1,0 +1,3 @@
+export default interface ZipDetails {
+  adrDocumentId: string;
+}

--- a/tests/unit/domain/getZip.test.ts
+++ b/tests/unit/domain/getZip.test.ts
@@ -1,0 +1,160 @@
+import { S3 } from 'aws-sdk';
+import MissingBucketNameError from '../../../src/errors/MissingBucketNameError';
+import NoBodyError from '../../../src/errors/NoBodyError';
+import IncorrectFileTypeError from '../../../src/errors/IncorrectFileTypeError';
+import MissingFolderNameError from '../../../src/errors/MissingFolderNameError';
+import getZip from '../../../src/domain/getZip';
+import FileNameError from '../../../src/errors/FileNameError';
+import ZipDetails from '../../../src/interfaces/ZipDetails';
+
+describe('getZip', () => {
+  it('returns an internal server error if the bucket is undefined', async () => {
+    const response = await getZip({} as ZipDetails, ({} as unknown) as S3, undefined, 'folder', 'test');
+    const error = new MissingBucketNameError();
+
+    expect(response.statusCode).toBe(500);
+    expect(response.body).toEqual(error.message);
+  });
+
+  it('returns an internal server error if the folder is undefined', async () => {
+    const response = await getZip({} as ZipDetails, ({} as unknown) as S3, 'bucket', undefined, 'test');
+    const error = new MissingFolderNameError();
+
+    expect(response.statusCode).toBe(500);
+    expect(response.body).toEqual(error.message);
+  });
+
+  it('returns a bad request if the file name is invalid', async () => {
+    const event: ZipDetails = {
+      adrDocumentId: undefined,
+    };
+    const response = await getZip(event, ({} as unknown) as S3, 'bucket', 'folder', 'test');
+    const error = new FileNameError();
+
+    expect(response.statusCode).toBe(400);
+    expect(response.body).toEqual(error.message);
+  });
+
+  it('returns an internal server error if there is no Body in the S3 request', async () => {
+    const mockS3 = ({} as unknown) as S3;
+    const mockPromise = jest.fn().mockReturnValue(Promise.resolve({ ContentType: 'application/octet-stream' }));
+    const mockGetObject = jest.fn().mockReturnValue({ promise: mockPromise });
+
+    mockS3.getObject = mockGetObject;
+
+    const event: ZipDetails = {
+      adrDocumentId: '1234',
+    };
+    const response = await getZip(event, mockS3, 'bucket', 'folder', 'test');
+    const error = new NoBodyError();
+
+    expect(response.statusCode).toBe(500);
+    expect(response.body).toEqual(error.message);
+  });
+
+  it('returns an 404 if the stored file is not a ZIP', async () => {
+    const mockS3 = ({} as unknown) as S3;
+    const mockPromise = jest
+      .fn()
+      .mockReturnValue(Promise.resolve({ Body: 'This is an image', ContentType: 'image/jpg' }));
+    const mockGetObject = jest.fn().mockReturnValue({ promise: mockPromise });
+
+    mockS3.getObject = mockGetObject;
+
+    const event: ZipDetails = {
+      adrDocumentId: '1234',
+    };
+    const response = await getZip(event, mockS3, 'bucket', 'folder', 'test');
+    const error = new IncorrectFileTypeError();
+
+    expect(response.statusCode).toBe(404);
+    expect(response.body).toEqual(error.message);
+  });
+
+  it('returns a not found error if the file is not found', async () => {
+    const mockS3 = ({} as unknown) as S3;
+    const mockPromise = jest.fn().mockReturnValue(Promise.reject(({ code: 'NoSuchKey' } as unknown) as Error)); // eslint-disable-line prefer-promise-reject-errors
+    const mockGetObject = jest.fn().mockReturnValue({ promise: mockPromise });
+
+    mockS3.getObject = mockGetObject;
+
+    const event: ZipDetails = {
+      adrDocumentId: '1234',
+    };
+    const response = await getZip(event, mockS3, 'bucket', 'folder', 'test');
+
+    expect(response.statusCode).toBe(404);
+    expect(response.body).toBe('NoSuchKey');
+  });
+
+  it('returns an internal server error if the S3 get fails for any other reason', async () => {
+    const mockS3 = ({} as unknown) as S3;
+    const mockPromise = jest.fn().mockReturnValue(Promise.reject(({ code: 'Generic Error' } as unknown) as Error)); // eslint-disable-line prefer-promise-reject-errors
+    const mockGetObject = jest.fn().mockReturnValue({ promise: mockPromise });
+
+    mockS3.getObject = mockGetObject;
+
+    const event: ZipDetails = {
+      adrDocumentId: '1234',
+    };
+    const response = await getZip(event, mockS3, 'bucket', 'folder', 'test');
+
+    expect(response.statusCode).toBe(500);
+    expect(response.body).toBe('Generic Error');
+  });
+
+  it('returns a successful response if everything works', async () => {
+    const mockS3 = ({} as unknown) as S3;
+    const mockPromise = jest
+      .fn()
+      .mockReturnValue(Promise.resolve({ Body: 'Certificate Content', ContentType: 'application/octet-stream' }));
+    const mockGetObject = jest.fn().mockReturnValue({ promise: mockPromise });
+
+    mockS3.getObject = mockGetObject;
+
+    const event: ZipDetails = {
+      adrDocumentId: '1234',
+    };
+    const response = await getZip(event, mockS3, 'bucket', 'folder', 'test');
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toBe('Certificate Content');
+  });
+
+  it('base64 encodes the response', async () => {
+    const mockS3 = ({} as unknown) as S3;
+    const body = Buffer.from('Certificate Content');
+    const mockPromise = jest
+      .fn()
+      .mockReturnValue(Promise.resolve({ Body: body, ContentType: 'application/octet-stream' }));
+    const mockGetObject = jest.fn().mockReturnValue({ promise: mockPromise });
+
+    mockS3.getObject = mockGetObject;
+
+    const event: ZipDetails = {
+      adrDocumentId: '1234',
+    };
+    const response = await getZip(event, mockS3, 'bucket', 'folder', 'test');
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toEqual(body.toString('base64'));
+  });
+
+  it('ignores the folder check if the current environment is "local". Required for local testing', async () => {
+    const mockS3 = ({} as unknown) as S3;
+    const mockPromise = jest
+      .fn()
+      .mockReturnValue(Promise.resolve({ Body: 'Zip Content', ContentType: 'application/octet-stream' }));
+    const mockGetObject = jest.fn().mockReturnValue({ promise: mockPromise });
+
+    mockS3.getObject = mockGetObject;
+
+    const event: ZipDetails = {
+      adrDocumentId: '1234',
+    };
+    const response = await getZip(event, mockS3, 'bucket', undefined, 'local');
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toBe('Zip Content');
+  });
+});

--- a/tests/unit/domain/getZip.test.ts
+++ b/tests/unit/domain/getZip.test.ts
@@ -73,7 +73,7 @@ describe('getZip', () => {
 
   it('returns a not found error if the file is not found', async () => {
     const mockS3 = ({} as unknown) as S3;
-    const mockPromise = jest.fn().mockReturnValue(Promise.reject(({ code: 'NoSuchKey' } as unknown) as Error)); // eslint-disable-line prefer-promise-reject-errors
+    const mockPromise = jest.fn().mockReturnValue(Promise.reject(({ code: 'NoSuchKey' } as unknown) as Error));
     const mockGetObject = jest.fn().mockReturnValue({ promise: mockPromise });
 
     mockS3.getObject = mockGetObject;
@@ -89,7 +89,7 @@ describe('getZip', () => {
 
   it('returns an internal server error if the S3 get fails for any other reason', async () => {
     const mockS3 = ({} as unknown) as S3;
-    const mockPromise = jest.fn().mockReturnValue(Promise.reject(({ code: 'Generic Error' } as unknown) as Error)); // eslint-disable-line prefer-promise-reject-errors
+    const mockPromise = jest.fn().mockReturnValue(Promise.reject(({ code: 'Generic Error' } as unknown) as Error));
     const mockGetObject = jest.fn().mockReturnValue({ promise: mockPromise });
 
     mockS3.getObject = mockGetObject;

--- a/tests/unit/infrastructure/api/index.test.ts
+++ b/tests/unit/infrastructure/api/index.test.ts
@@ -4,6 +4,7 @@ import { app } from '../../../../src/infrastructure/api';
 import getCertificate from '../../../../src/domain/getCertificate';
 import getPlate from '../../../../src/domain/getPlate';
 import getLetter from '../../../../src/domain/getLetter';
+import getZip from '../../../../src/domain/getZip';
 
 // TODO Define Mock strategy
 describe('API', () => {
@@ -130,5 +131,28 @@ describe('/document-retrieval', () => {
 
     expect(result.headers).toHaveProperty('content-type');
     expect(result.get('content-type')).toContain('application/pdf');
+  });
+
+  it('returns the expected body and status from the getZip call', async () => {
+    process.env.NODE_ENV = 'local';
+    (getZip as jest.Mock) = jest.fn().mockResolvedValue({ statusCode: 200, body: 'this is a test' });
+    const result = await supertest(app).get('/document-retrieval?adrDocumentId=1234');
+
+    expect(result.status).toBe(200);
+    expect(result.text).toBe('this is a test');
+  });
+
+  it('adds the header returned from the getZip call', async () => {
+    (getZip as jest.Mock) = jest.fn().mockResolvedValue({
+      statusCode: 200,
+      body: 'this is a test',
+      headers: {
+        'Content-Type': 'application/zip',
+      },
+    });
+    const result = await supertest(app).get('/document-retrieval?adrDocumentId=1234');
+
+    expect(result.headers).toHaveProperty('content-type');
+    expect(result.get('content-type')).toContain('application/zip');
   });
 });

--- a/tests/unit/infrastructure/api/index.test.ts
+++ b/tests/unit/infrastructure/api/index.test.ts
@@ -134,7 +134,6 @@ describe('/document-retrieval', () => {
   });
 
   it('returns the expected body and status from the getZip call', async () => {
-    process.env.NODE_ENV = 'local';
     (getZip as jest.Mock) = jest.fn().mockResolvedValue({ statusCode: 200, body: 'this is a test' });
     const result = await supertest(app).get('/document-retrieval?adrDocumentId=1234');
 

--- a/tests/unit/infrastructure/api/index.test.ts
+++ b/tests/unit/infrastructure/api/index.test.ts
@@ -5,7 +5,7 @@ import getCertificate from '../../../../src/domain/getCertificate';
 import getPlate from '../../../../src/domain/getPlate';
 import getLetter from '../../../../src/domain/getLetter';
 import getZip from '../../../../src/domain/getZip';
-import getFile from "../../../../src/domain/getFile";
+import getFile from '../../../../src/domain/getFile';
 
 // TODO Define Mock strategy
 describe('API', () => {
@@ -177,9 +177,13 @@ describe('/document-retrieval', () => {
     expect(result.get('content-type')).toContain('application/zip');
   });
 
-  it('should catch error and log error message', async () => {
-    (getCertificate as jest.Mock) = jest.fn().mockRejectedValue(new Error('Error message'));
-    const result = await supertest(app).get('/document-retrieval?vinNumber=1234&testNumber=1234');
+  it('should catch error, log message and return status code 500', async () => {
+    const logSpy = jest.spyOn(console, 'error');
+    (getZip as jest.Mock) = jest.fn().mockRejectedValue(new Error('Error message'));
+    const result = await supertest(app).get('/document-retrieval?adrDocumentId=1234');
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy).toHaveBeenCalledWith('Error message');
     expect(result.status).toBe(500);
+    logSpy.mockClear();
   });
 });

--- a/tests/unit/infrastructure/s3/s3ZipService.test.ts
+++ b/tests/unit/infrastructure/s3/s3ZipService.test.ts
@@ -28,7 +28,7 @@ describe('S3 Zip Service', () => {
   it('passes the expected key to getObject if folder is undefined', async () => {
     const mockS3 = ({} as unknown) as S3;
     const bucket = 'bucket';
-    const folder = undefined;
+    const folder: string | undefined = undefined;
     const adrDocumentId = '1234';
     const mockPromise = jest
       .fn()
@@ -36,7 +36,6 @@ describe('S3 Zip Service', () => {
     const mockGetObject = jest.fn().mockReturnValue({ promise: mockPromise });
 
     mockS3.getObject = mockGetObject;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     await getFromS3(mockS3, bucket, folder, adrDocumentId).catch(() => {});
 
     const firstCall = mockGetObject.mock.calls[0] as S3.GetObjectRequest[];

--- a/tests/unit/infrastructure/s3/s3ZipService.test.ts
+++ b/tests/unit/infrastructure/s3/s3ZipService.test.ts
@@ -22,7 +22,7 @@ describe('S3 Zip Service', () => {
     const firstCall = mockGetObject.mock.calls[0] as S3.GetObjectRequest[];
     const firstArg = firstCall[0];
 
-    expect(firstArg.Key).toBe(`${folder}/${fileName}.zip`);
+    expect(firstArg.Key).toBe(`${folder}/adr-documents/${fileName}.zip`);
   });
 
   it('passes the expected key to getObject if folder is undefined', async () => {
@@ -42,7 +42,7 @@ describe('S3 Zip Service', () => {
     const firstCall = mockGetObject.mock.calls[0] as S3.GetObjectRequest[];
     const firstArg = firstCall[0];
 
-    expect(firstArg.Key).toBe(`${fileName}.zip`);
+    expect(firstArg.Key).toBe(`/adr-documents/${fileName}.zip`);
   });
 
   it('passes the bucket to getObject', () => {

--- a/tests/unit/infrastructure/s3/s3ZipService.test.ts
+++ b/tests/unit/infrastructure/s3/s3ZipService.test.ts
@@ -10,26 +10,26 @@ describe('S3 Zip Service', () => {
     const mockS3 = ({} as unknown) as S3;
     const bucket = 'bucket';
     const folder = 'folder';
-    const fileName = '1234';
+    const adrDocumentId = '1234';
     const mockPromise = jest
       .fn()
       .mockResolvedValue({ Body: 'Success!', ContentType: 'application/octet-stream' });
     const mockGetObject = jest.fn().mockReturnValue({ promise: mockPromise });
 
     mockS3.getObject = mockGetObject;
-    await getFromS3(mockS3, bucket, folder, fileName).catch(() => {});
+    await getFromS3(mockS3, bucket, folder, adrDocumentId).catch(() => {});
 
     const firstCall = mockGetObject.mock.calls[0] as S3.GetObjectRequest[];
     const firstArg = firstCall[0];
 
-    expect(firstArg.Key).toBe(`${folder}/adr-documents/${fileName}.zip`);
+    expect(firstArg.Key).toBe(`${folder}/adr-documents/${adrDocumentId}.zip`);
   });
 
   it('passes the expected key to getObject if folder is undefined', async () => {
     const mockS3 = ({} as unknown) as S3;
     const bucket = 'bucket';
     const folder = undefined;
-    const fileName = '1234';
+    const adrDocumentId = '1234';
     const mockPromise = jest
       .fn()
       .mockReturnValue(Promise.resolve({ Body: 'Success!', ContentType: 'application/octet-stream' }));
@@ -37,26 +37,26 @@ describe('S3 Zip Service', () => {
 
     mockS3.getObject = mockGetObject;
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-    await getFromS3(mockS3, bucket, folder, fileName).catch(() => {});
+    await getFromS3(mockS3, bucket, folder, adrDocumentId).catch(() => {});
 
     const firstCall = mockGetObject.mock.calls[0] as S3.GetObjectRequest[];
     const firstArg = firstCall[0];
 
-    expect(firstArg.Key).toBe(`/adr-documents/${fileName}.zip`);
+    expect(firstArg.Key).toBe(`/adr-documents/${adrDocumentId}.zip`);
   });
 
   it('passes the bucket to getObject', () => {
     const mockS3 = ({} as unknown) as S3;
     const bucket = 'bucket';
     const folder = 'folder';
-    const fileName = '1234';
+    const adrDocumentId = '1234';
     const mockPromise = jest
       .fn()
       .mockReturnValue(Promise.resolve({ Body: 'Success!', ContentType: 'application/octet-stream' }));
     const mockGetObject = jest.fn().mockReturnValue({ promise: mockPromise });
 
     mockS3.getObject = mockGetObject;
-    getFromS3(mockS3, bucket, folder, fileName).catch(() => {});
+    getFromS3(mockS3, bucket, folder, adrDocumentId).catch(() => {});
 
     const firstCall = mockGetObject.mock.calls[0] as S3.GetObjectRequest[];
     const firstArg = firstCall[0];
@@ -68,7 +68,7 @@ describe('S3 Zip Service', () => {
     const mockS3 = ({} as unknown) as S3;
     const bucket = 'bucket';
     const folder = 'folder';
-    const fileName = '1234';
+    const adrDocumentId = '1234';
     const mockPromise = jest
       .fn()
       .mockReturnValue(Promise.resolve({ Body: 'Success!', ContentType: 'application/octet-stream' }));
@@ -76,32 +76,32 @@ describe('S3 Zip Service', () => {
 
     mockS3.getObject = mockGetObject;
 
-    expect(await getFromS3(mockS3, bucket, folder, fileName)).toBe('Success!');
+    expect(await getFromS3(mockS3, bucket, folder, adrDocumentId)).toBe('Success!');
   });
 
   it('throws an error if the response is not a ZIP', async () => {
     const mockS3 = ({} as unknown) as S3;
     const bucket = 'bucket';
     const folder = 'folder';
-    const fileName = '1234';
+    const adrDocumentId = '1234';
     const mockPromise = jest.fn().mockReturnValue(Promise.resolve({ Body: 'Success!', ContentType: 'image/jpg' }));
     const mockGetObject = jest.fn().mockReturnValue({ promise: mockPromise });
 
     mockS3.getObject = mockGetObject;
 
-    await expect(getFromS3(mockS3, bucket, folder, fileName)).rejects.toThrow();
+    await expect(getFromS3(mockS3, bucket, folder, adrDocumentId)).rejects.toThrow();
   });
 
   it('throws an error if there is no body in the response', async () => {
     const mockS3 = ({} as unknown) as S3;
     const bucket = 'bucket';
     const folder = 'folder';
-    const fileName = '1234';
+    const adrDocumentId = '1234';
     const mockPromise = jest.fn().mockReturnValue(Promise.resolve({ ContentType: 'application/octet-stream' }));
     const mockGetObject = jest.fn().mockReturnValue({ promise: mockPromise });
 
     mockS3.getObject = mockGetObject;
 
-    await expect(getFromS3(mockS3, bucket, folder, fileName)).rejects.toThrow();
+    await expect(getFromS3(mockS3, bucket, folder, adrDocumentId)).rejects.toThrow();
   });
 });

--- a/tests/unit/infrastructure/s3/s3ZipService.test.ts
+++ b/tests/unit/infrastructure/s3/s3ZipService.test.ts
@@ -1,0 +1,107 @@
+import { S3 } from 'aws-sdk';
+import getFromS3 from '../../../../src/infrastructure/s3/s3ZipService';
+
+describe('S3 Zip Service', () => {
+  afterEach(() => {
+    jest.resetAllMocks().restoreAllMocks();
+  });
+
+  it('passes the expected key to getObject if folder is defined', async () => {
+    const mockS3 = ({} as unknown) as S3;
+    const bucket = 'bucket';
+    const folder = 'folder';
+    const fileName = '1234';
+    const mockPromise = jest
+      .fn()
+      .mockResolvedValue({ Body: 'Success!', ContentType: 'application/octet-stream' });
+    const mockGetObject = jest.fn().mockReturnValue({ promise: mockPromise });
+
+    mockS3.getObject = mockGetObject;
+    await getFromS3(mockS3, bucket, folder, fileName).catch(() => {});
+
+    const firstCall = mockGetObject.mock.calls[0] as S3.GetObjectRequest[];
+    const firstArg = firstCall[0];
+
+    expect(firstArg.Key).toBe(`${folder}/${fileName}.zip`);
+  });
+
+  it('passes the expected key to getObject if folder is undefined', async () => {
+    const mockS3 = ({} as unknown) as S3;
+    const bucket = 'bucket';
+    const folder = undefined;
+    const fileName = '1234';
+    const mockPromise = jest
+      .fn()
+      .mockReturnValue(Promise.resolve({ Body: 'Success!', ContentType: 'application/octet-stream' }));
+    const mockGetObject = jest.fn().mockReturnValue({ promise: mockPromise });
+
+    mockS3.getObject = mockGetObject;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+    await getFromS3(mockS3, bucket, folder, fileName).catch(() => {});
+
+    const firstCall = mockGetObject.mock.calls[0] as S3.GetObjectRequest[];
+    const firstArg = firstCall[0];
+
+    expect(firstArg.Key).toBe(`${fileName}.zip`);
+  });
+
+  it('passes the bucket to getObject', () => {
+    const mockS3 = ({} as unknown) as S3;
+    const bucket = 'bucket';
+    const folder = 'folder';
+    const fileName = '1234';
+    const mockPromise = jest
+      .fn()
+      .mockReturnValue(Promise.resolve({ Body: 'Success!', ContentType: 'application/octet-stream' }));
+    const mockGetObject = jest.fn().mockReturnValue({ promise: mockPromise });
+
+    mockS3.getObject = mockGetObject;
+    getFromS3(mockS3, bucket, folder, fileName).catch(() => {});
+
+    const firstCall = mockGetObject.mock.calls[0] as S3.GetObjectRequest[];
+    const firstArg = firstCall[0];
+
+    expect(firstArg.Bucket).toEqual(bucket);
+  });
+
+  it('returns the expected output', async () => {
+    const mockS3 = ({} as unknown) as S3;
+    const bucket = 'bucket';
+    const folder = 'folder';
+    const fileName = '1234';
+    const mockPromise = jest
+      .fn()
+      .mockReturnValue(Promise.resolve({ Body: 'Success!', ContentType: 'application/octet-stream' }));
+    const mockGetObject = jest.fn().mockReturnValue({ promise: mockPromise });
+
+    mockS3.getObject = mockGetObject;
+
+    expect(await getFromS3(mockS3, bucket, folder, fileName)).toBe('Success!');
+  });
+
+  it('throws an error if the response is not a ZIP', async () => {
+    const mockS3 = ({} as unknown) as S3;
+    const bucket = 'bucket';
+    const folder = 'folder';
+    const fileName = '1234';
+    const mockPromise = jest.fn().mockReturnValue(Promise.resolve({ Body: 'Success!', ContentType: 'image/jpg' }));
+    const mockGetObject = jest.fn().mockReturnValue({ promise: mockPromise });
+
+    mockS3.getObject = mockGetObject;
+
+    await expect(getFromS3(mockS3, bucket, folder, fileName)).rejects.toThrow();
+  });
+
+  it('throws an error if there is no body in the response', async () => {
+    const mockS3 = ({} as unknown) as S3;
+    const bucket = 'bucket';
+    const folder = 'folder';
+    const fileName = '1234';
+    const mockPromise = jest.fn().mockReturnValue(Promise.resolve({ ContentType: 'application/octet-stream' }));
+    const mockGetObject = jest.fn().mockReturnValue({ promise: mockPromise });
+
+    mockS3.getObject = mockGetObject;
+
+    await expect(getFromS3(mockS3, bucket, folder, fileName)).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## Amend doc-retrieval to be able to retrieve ZIP file for ADR Document

Currently ADR documents (e.g. Tank Certificates) are stored in the ADR application on a legacy system. In order to exit this lecacy system we need to provide a way for these documents to be retrieved. This change provides a route whereby a zip file stored in an s3 bucket can be retrieved by providing the technicalId associated with the technical record as a query parameter. Base64 encoded zip file is then returned in the response.

-- Added logic for new getZip route
-- Added unit tests for new getZip route
-- Added unit tests for getFile for greater test coverage

[CB2-11288](https://dvsa.atlassian.net/browse/CB2-11288)

## Checklist
- [X] Code has been tested manually
- [X] PR title includes the JIRA ticket number
- [X] Branch is rebased against the latest develop
- [X] Squashed commit contains the JIRA ticket number